### PR TITLE
Update to version 5.3.x

### DIFF
--- a/Classes/Controller/Backend/LibraryController.php
+++ b/Classes/Controller/Backend/LibraryController.php
@@ -5,7 +5,7 @@ namespace Sandstorm\NeosH5P\Controller\Backend;
 use Neos\Error\Messages\Message;
 use Neos\Flow\Mvc\Exception\StopActionException;
 use Neos\Flow\Mvc\View\ViewInterface;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Neos\Controller\Module\AbstractModuleController;
 use Sandstorm\NeosH5P\Domain\Model\Library;
 use Sandstorm\NeosH5P\Domain\Repository\ContentRepository;
@@ -62,7 +62,7 @@ class LibraryController extends AbstractModuleController
 
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Classes/DataSource/ContentDataSource.php
+++ b/Classes/DataSource/ContentDataSource.php
@@ -33,7 +33,7 @@ class ContentDataSource extends AbstractDataSource
      * @param array $arguments
      * @return array
      */
-    public function getData(NodeInterface $node = null, array $arguments)
+    public function getData(NodeInterface $node = null, array $arguments = [])
     {
         /** @var Content $content */
         $content = $this->contentRepository->findOneByContentId($arguments['contentId']);

--- a/Classes/Domain/Service/H5PIntegrationService.php
+++ b/Classes/Domain/Service/H5PIntegrationService.php
@@ -78,7 +78,7 @@ class H5PIntegrationService
 
     /**
      * @Flow\Inject
-     * @var PackageManager
+     * @var PackageManager 
      */
     protected $packageManager;
 

--- a/Classes/Domain/Service/H5PIntegrationService.php
+++ b/Classes/Domain/Service/H5PIntegrationService.php
@@ -4,7 +4,7 @@ namespace Sandstorm\NeosH5P\Domain\Service;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ControllerContext;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Flow\Security\Account;
 use Neos\Flow\Security\Context;
@@ -78,7 +78,7 @@ class H5PIntegrationService
 
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Classes/Domain/Service/H5PIntegrationService.php
+++ b/Classes/Domain/Service/H5PIntegrationService.php
@@ -6,6 +6,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Flow\Package\PackageManager;
 use Neos\Flow\ResourceManagement\ResourceManager;
+use Neos\Flow\Http\BaseUriProvider;
 use Neos\Flow\Security\Account;
 use Neos\Flow\Security\Context;
 use Sandstorm\NeosH5P\Domain\Model\Content;
@@ -88,6 +89,12 @@ class H5PIntegrationService
      */
     protected $resourceManager;
 
+    /**
+     * @Flow\Inject
+     * @var BaseUriProvider
+     */
+    protected $baseUriProvider;    
+    
     /**
      * @Flow\Inject
      * @var Context
@@ -472,7 +479,6 @@ class H5PIntegrationService
      */
     private function getBaseUri(ControllerContext $cc): string
     {
-        // rtrim to remove any trailing slashes
-        return rtrim($cc->getRequest()->getMainRequest()->getHttpRequest()->getBaseUri()->__toString(), '/');
+        return $this->baseUriProvider->getConfiguredBaseUriOrFallbackToCurrentRequest();
     }
 }

--- a/Classes/H5PAdapter/Core/H5PFramework.php
+++ b/Classes/H5PAdapter/Core/H5PFramework.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use Neos\Flow\Exception;
 use Neos\Flow\ObjectManagement\DependencyInjection\DependencyProxy;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Persistence\QueryInterface;
@@ -64,7 +64,7 @@ class H5PFramework implements \H5PFrameworkInterface
 
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Classes/H5PAdapter/Core/H5PFramework.php
+++ b/Classes/H5PAdapter/Core/H5PFramework.php
@@ -64,7 +64,7 @@ class H5PFramework implements \H5PFrameworkInterface
 
     /**
      * @Flow\Inject
-     * @var PackageManager
+     * @var PackageManager 
      */
     protected $packageManager;
 

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -18,7 +18,7 @@ prototype(Sandstorm.NeosH5P:H5PScriptsAndStyles) < prototype(Neos.Neos:Plugin) {
     h5pContentNodes = ${q(documentNode).find('[instanceof Sandstorm.NeosH5P:H5PContent]')}
 }
 
-prototype(Sandstorm.NeosH5P:H5PContent) {
+prototype(Sandstorm.NeosH5P:H5PContent) < prototype(Neos.Neos:Plugin) {
     controller = 'Plugin\\Content'
     action = 'content'
 }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "h5p/h5p-core": "~1.24.0",
         "h5p/h5p-editor": "~1.24.1",
         "guzzlehttp/guzzle": "~6.3.0",
-
         "ext-zip": "*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     "require": {
         "neos/neos": ">=4.0.0",
         "neos/neos-ui": "*",
-        "h5p/h5p-core": "~1.20.0",
-        "h5p/h5p-editor": "~1.20.0",
+        "h5p/h5p-core": "~1.24.0",
+        "h5p/h5p-editor": "~1.24.1",
         "guzzlehttp/guzzle": "~6.3.0",
 
         "ext-zip": "*"


### PR DESCRIPTION
Applying the changes NeosH5P may be installed without any errors, however trying to create a new H5P content type in a page context will throw the following error: 
The form you are trying to render requires an enctype of "multipart/form-data". Please specify the correct enctype when using file uploads.
It also appears that files like "FullscreenEditor.css" cannot be located/loaded properly. How to follow up on this?